### PR TITLE
VS Code LaTeX Workshop fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "latex-workshop.latex.rootFile.indicator": "\\begin{document}"
+}


### PR DESCRIPTION
Added a vscode setting that changes the way LaTeX Workshop looks for root files.

By default it uses `\documentclass[]{}`   which is contained only in the `shared.tex` file. It obviously fails the build because this file does not begin the document and rather is input from within each `main.tex` file in the repo. 

This PR changes that LaTeX Workshop to search for `\begin{document}` instead which fixes the behavior.